### PR TITLE
Unified mobile gradient behind FAB and bottom tab menu

### DIFF
--- a/src/frontend/app/root.tsx
+++ b/src/frontend/app/root.tsx
@@ -6,6 +6,7 @@ import {
     Scripts,
     ScrollRestoration,
     NavLink,
+    useLocation,
     useSearchParams,
 } from "react-router";
 import type {Route} from "./+types/root";
@@ -117,6 +118,8 @@ function AppShell({children}: { children: React.ReactNode }) {
     const {isAuthenticated, isLoading, getAccessTokenSilently} = useAuth0();
     const forbidden = useSelector((s: RootState) => s.auth.forbidden);
     const dispatch = useDispatch();
+    const {pathname} = useLocation();
+    const hasFab = pathname === "/" || pathname === "/seasons";
 
     useEffect(() => {
         if (!isAuthenticated) dispatch(setForbidden(false));
@@ -173,11 +176,16 @@ function AppShell({children}: { children: React.ReactNode }) {
             {/* Page content */}
             <main>{children}</main>
 
+            {/* Mobile bottom gradient — extends above the nav to cover the FAB on routes that have one */}
+            <div
+                className={`md:hidden fixed left-0 right-0 bottom-0 pointer-events-none z-30 bg-gradient-to-t from-background to-transparent ${
+                    hasFab ? "h-40 from-40%" : "h-16 from-60%"
+                }`}
+            />
+
             {/* Mobile bottom tabs */}
             <nav className="md:hidden fixed bottom-0 left-0 right-0 z-50">
-                <div
-                    className="absolute inset-0 bg-gradient-to-t from-background from-60% to-transparent pointer-events-none"/>
-                <div className="relative flex items-center justify-around h-16 px-2">
+                <div className="flex items-center justify-around h-16 px-2">
                     {navItems.map(({to, label, icon: Icon, activeMobile}) => (
                         <NavLink
                             key={to}

--- a/src/frontend/app/routes/leaderboard.tsx
+++ b/src/frontend/app/routes/leaderboard.tsx
@@ -297,7 +297,7 @@ export default function Leaderboard() {
       )}
 
       {/* Start Game — sticky at bottom of viewport, in flow after list */}
-      <div className="sticky bottom-20 md:bottom-0 z-40 flex justify-center pt-8 pb-4 mt-2 bg-gradient-to-b from-transparent to-background">
+      <div className="sticky bottom-20 md:bottom-0 z-40 flex justify-center pt-8 pb-4 mt-2 md:bg-gradient-to-b md:from-transparent md:to-background">
         <Link
           to="/game"
           className="bg-orange-500 hover:bg-orange-600 text-white rounded-2xl px-8 py-3 font-bold shadow-lg shadow-orange-500/25 inline-flex items-center gap-2 hover:scale-105 active:scale-95 transition-all"

--- a/src/frontend/app/routes/seasons.tsx
+++ b/src/frontend/app/routes/seasons.tsx
@@ -281,7 +281,7 @@ export default function Seasons() {
       )}
 
       {/* Start New Season — sticky at bottom */}
-      <div className="sticky bottom-20 md:bottom-0 z-40 flex justify-center pt-8 pb-4 mt-2 bg-gradient-to-b from-transparent to-background">
+      <div className="sticky bottom-20 md:bottom-0 z-40 flex justify-center pt-8 pb-4 mt-2 md:bg-gradient-to-b md:from-transparent md:to-background">
         <button
           onClick={() => { setNewName(generateSeasonName()); setDialogOpen(true); }}
           className="bg-emerald-600 hover:bg-emerald-700 text-white rounded-2xl px-8 py-3 font-bold shadow-lg shadow-emerald-600/25 inline-flex items-center gap-2 hover:scale-105 active:scale-95 transition-all"


### PR DESCRIPTION
On mobile (/) and (/seasons) the sticky Start Game / Start New Season FAB and the bottom tab menu each rendered their own gradient, creating a visible double-seam. Replaced with a single route-aware fixed overlay at z-30 that extends above the nav when a FAB is present; desktop keeps the FAB's own transparent-to-background gradient.